### PR TITLE
Updated/Fixed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,14 @@
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
 #
-/[Ll]ibrary/
-/[Tt]emp/
-/[Oo]bj/
-/[Bb]uild/
-/[Bb]uilds/
-/[Ll]ogs/
-/[Uu]ser[Ss]ettings/
+
+/My project (1)/[Ll]ibrary/
+/My project (1)/[Tt]emp/
+/My project (1)/[Oo]bj/
+/My project (1)/[Bb]uild/
+/My project (1)/[Bb]uilds/
+/My project (1)/[Ll]ogs/
+/My project (1)/[Uu]ser[Ss]ettings/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
Previous .gitignore file was not working as intended. The main folders to ignore (Library, Temp, Obj, Build, Builds, Logs and UserSettings) never actually got ignored.

This lead to ~9000 files (~250mb) being committed that are not needed for the project to function (the files are mostly cache files).

Just wanted to propose a QoL update/upgrade to the .gitignore as it would make commits smaller, the repo smaller and possibly help out future CSC250 classes :)